### PR TITLE
Allow graceful shutdown of Porter workers

### DIFF
--- a/lib/queue.coffee
+++ b/lib/queue.coffee
@@ -16,19 +16,19 @@ class Queue
 
   @lock_name: (name, namespace = settings.namespace) ->
     "#{namespace}:l:#{name}"
-  
+
   @queue_name: (name, namespace = settings.namespace) ->
     "#{namespace}:q:#{name}"
 
   @work_queue_name: (name, namespace = settings.namespace) ->
     "#{namespace}:w:#{name}"
-  
+
   @stats_hash_name: (name, type, namespace = settings.namespace) ->
     if type is 'queue'
       "#{namespace}:s:q:#{name}"
     else if type is 'command'
       "#{namespace}:s:c:#{name}"
-  
+
   lock_name: (name) -> Queue.lock_name(name, @_namespace)
   queue_name: (name) -> Queue.queue_name(name, @_namespace)
   work_queue_name: (name) -> Queue.work_queue_name(name, @_namespace)
@@ -36,11 +36,11 @@ class Queue
 
   constructor: (queue_name, options = {}) ->
     @name = queue_name
-    
+
     @_namespace = options.namespace || settings.namespace
     @_timeout = options.timeout || settings.timeout
     @_payload_storage = options.payload_storage || settings.payload_storage
-    
+
     @_base_queue_name = queue_name
     @_queue_name = @queue_name(queue_name)
     @_work_queue_name = @work_queue_name(queue_name)
@@ -58,28 +58,28 @@ class Queue
 
     @_payload_storage.store e, (err) =>
       return callback?(err) if err?
-    
+
       client.lpush @_queue_name, e.id, (err) =>
         return callback?(err) if err?
         callback?(null, new Envelope(e, @))
-  
+
   pop: (callback) ->
     client = create_client()
     client.rpoplpush @_queue_name, @_work_queue_name, (err, envelope_id) =>
       return callback(err) if err?
       return callback() unless envelope_id?
-      
+
       @_payload_storage.load envelope_id, (err, e) =>
         return callback(err) if err?
         unless e?
           return client.lrem @_work_queue_name, -1, envelope_id, (err) ->
             return callback(err) if err?
             callback()
-        
+
         e.popped_at = new Date().getTime()
         client.setex(@lock_name(e.id), @_timeout, 1)
         callback(null, new Envelope(e, @))
-  
+
   peek: (how_many, callback) ->
     client = create_client()
     if typeof how_many is 'function'
@@ -88,7 +88,7 @@ class Queue
     client.lrange @_queue_name, -how_many, -1, (err, items) =>
       return callback(err) if err?
       @_payload_storage.load_many items, callback
-  
+
   remove: (envelope, callback) ->
     client = create_client()
     envelope.removed_at = new Date().getTime()
@@ -105,28 +105,28 @@ class Queue
       .hincrby(@stats_hash_name(envelope.command, 'command'), 'queue_pop', envelope.popped_at - envelope.queued_at)
       .hincrby(@stats_hash_name(envelope.command, 'command'), 'pop_remove', envelope.removed_at - envelope.popped_at)
       .hincrby(@stats_hash_name(envelope.command, 'command'), 'queue_remove', envelope.removed_at - envelope.queued_at)
-      
+
       .exec (err, replies) =>
         return callback?(err) if err?
         return callback?(null, 0) if replies[0] is 0
         @_payload_storage.remove envelope.id, callback
-  
+
   count: (callback) ->
     create_client().llen @_queue_name, callback
-  
+
   work_count: (callback) ->
     create_client().llen @_work_queue_name, callback
-  
+
   stats: (callback) ->
     Queue.__stats__(@_stats_hash_name, callback)
-  
+
   commands: (callback) ->
     Queue.__commands__(@stats_hash_name(@_base_queue_name, 'command') + ':*', @stats_hash_name(@_base_queue_name, 'command') + ':', callback)
-  
+
   command_stats: (command, callback) ->
     command = "#{@_base_queue_name}:#{command}" unless command.indexOf(@_base_queue_name + ':') is 0
     Queue.__stats__(@stats_hash_name(command, 'command'), callback)
-  
+
   commands_stats: (callback) ->
     @commands (err, commands) =>
       return callback(err) if err?
@@ -150,14 +150,14 @@ class Queue
       @_payload_storage.remove_many items, (err) =>
         return callback?(err) if err?
         client.ltrim @_queue_name, 1, 0, callback
-  
+
   clear_stats: (callback) ->
     create_client().del @_stats_hash_name, callback
-  
+
   clear_command_stats: (command, callback) ->
     command = "#{@_base_queue_name}:#{command}" unless command.indexOf(@_base_queue_name + ':') is 0
     create_client().del(@stats_hash_name(command, 'command'), callback)
-  
+
   @__stats__: (search, callback) ->
     create_client().hgetall search, (err, stats) ->
       return callback(err) if err?
@@ -170,18 +170,18 @@ class Queue
       stats.avg_process_time = if stats.count is 0 then 0 else stats.pop_remove / stats.count
       stats.avg_queue_to_completion = if stats.count is 0 then 0 else stats.queue_remove / stats.count
       callback(null, stats)
-  
+
   @__commands__: (search, prefix_to_remove, callback) ->
     create_client().keys search, (err, commands) ->
       return callback(err) if err?
       callback(null, commands.map (q) -> q.slice(prefix_to_remove.length))
-  
+
   @commands: (callback) ->
     Queue.__commands__("#{settings.namespace}:s:c:*", "#{settings.namespace}:s:c:", callback)
 
   @command_stats: (command, callback) ->
     Queue.__stats__("#{settings.namespace}:s:c:#{command}", callback)
-  
+
   @queues: (callback) ->
     client = create_client()
     async.parallel {
@@ -218,7 +218,7 @@ class Queue
           }
           o
         , {})
-  
+
   @commands_stats: (callback) ->
     @commands (err, commands) ->
       return callback(err) if err?
@@ -239,15 +239,15 @@ class Queue
           }
           o
         , {})
-  
+
   @__reap__: (lock_name, queue_name, work_queue_name, callback) ->
     client = create_client()
     client.lrange work_queue_name, 0, -1, (err, items) ->
       return process.nextTick(-> callback?(null, 0)) if items.length is 0
-      
+
       count = 0
       cb = _.after items.length, -> callback?(null, count)
-      
+
       items.forEach (item) ->
         client.exists lock_name(item), (err, exists) ->
           return cb() if exists
@@ -257,7 +257,7 @@ class Queue
                 .exec ->
                   count += 1
                   cb()
-  
+
   @reap: (callback) ->
     @queues (err, queues) ->
       return callback?(err) if err?
@@ -268,7 +268,7 @@ class Queue
       ), (err, data) ->
         return callback?(err) if err?
         callback?(null, _(data).inject ((o, i) -> i + o), 0)
-  
+
   reap: (callback) ->
     Queue.__reap__(@lock_name, @_queue_name, @_work_queue_name, callback)
 

--- a/lib/redis_payload_storage.coffee
+++ b/lib/redis_payload_storage.coffee
@@ -15,10 +15,10 @@ exports.store_many = (envelopes, callback) ->
 
 exports.remove = (id, callback) ->
   client().del(id, callback)
-  
+
 exports.remove_many = (ids, callback) ->
   client().del(ids, callback)
-  
+
 exports.load = (id, callback) ->
   client().get id, (err, envelope) ->
     return callback(err) if err?

--- a/lib/worker.coffee
+++ b/lib/worker.coffee
@@ -212,6 +212,7 @@ class Worker extends EventEmitter
     @_state = 'graceful'
 
   graceful_stop: () ->
+    _.map(@_child_workers, (w) -> w.kill('SIGHUP'))
     process.exit(0)
 
   ready_for_graceful: () ->

--- a/lib/worker.coffee
+++ b/lib/worker.coffee
@@ -210,6 +210,7 @@ class Worker extends EventEmitter
 
   graceful: (callback) ->
     @_state = 'graceful'
+    callback?()
 
   graceful_stop: () ->
     _.map(@_child_workers, (w) -> w.kill('SIGHUP'))

--- a/lib/worker.coffee
+++ b/lib/worker.coffee
@@ -13,10 +13,10 @@ create_client = settings.redis.create_client
 log = ->
   arguments[0] = "[Worker #{process.pid}] #{arguments[0]}"
   console.log.apply(console, arguments)
-  
+
 pretty_mem = (value) ->
   "#{Math.floor(100 * value / (1024 * 1024)) / 100} MB"
-  
+
 flatten_object = (obj, into = {}, prefix = '', sep = '_') ->
   for own key, prop of obj
     if typeof prop is 'object' and prop not instanceof Date and prop not instanceof RegExp
@@ -24,67 +24,67 @@ flatten_object = (obj, into = {}, prefix = '', sep = '_') ->
     else
       into[prefix + key] = prop
   into
-  
+
 
 class Registry
   constructor: ->
     @commands = {}
-    
+
   register: (commands) ->
     _(@commands).extend(commands)
-  
+
   get: (command) ->
     @commands[command]
-  
+
   queues: ->
     _.chain(@commands).keys().map((c) -> c.split(':')[0]).uniq().value()
 
 class Worker extends EventEmitter
   @registry = new Registry()
-  
+
   @on: (command, func) ->
     o = {}
     o[command] = func
     @registry.register(o)
-  
+
   constructor: (options = {}) ->
     @_is_child = process.send?
-    
+
     @_queue_cache = {}
     @_queues = options.queues || settings.worker.queues
     Object.defineProperty(@, '_queues', {get: -> Worker.registry.queues()}) unless @_queues?
-    
+
     @_min_poll_timeout = options.min_poll_timeout || settings.worker.min_poll_timeout
     @_max_poll_timeout = options.max_poll_timeout || settings.worker.max_poll_timeout
     @_concurrent_commands = options.concurrent_commands || settings.worker.concurrent_commands
 
     @_timeout = options.timeout || settings.timeout
-    
+
     @_current_queue = 0
     @_current_commands = {}
     @_current_poll_timeout = @_min_poll_timeout
 
     @_state = 'uninitialized'
-    
+
     @_child_workers = []
     @_all_children = []
-    
+
     @_worker_heartbeat = new WorkerHeartbeat(@)
-    
+
     @name = process.pid + new Date().getTime() + require('crypto').randomBytes(8).toString('hex')
-  
+
   initialize: (callback) ->
     return unless @_state is 'uninitialized'
     @_state = 'initializing'
     @emit(@_state)
-    
+
     async.map _.range(@_concurrent_commands), (idx, cb) ->
       start_child = (command, args) ->
         log "Starting child #{command} #{args.join(' ')}"
         child = child_process.fork(command, args, {cwd: '.', env: process.env})
         child.on 'message', (msg) ->
           cb(null, child) if msg.status is 'ready'
-      
+
       if process.argv[0] is 'node'
         start_child(process.argv[1], process.argv.slice(2))
       else if process.argv[0] is 'coffee'
@@ -96,13 +96,13 @@ class Worker extends EventEmitter
       @_state = 'initialized'
       callback()
       @emit(@_state)
-  
+
   next_queue: ->
     queues = @_queues
     @_current_queue = (@_current_queue + 1) % queues.length
     queue_name = queues[@_current_queue]
     @_queue_cache[queue_name] ||= new Queue(queues[@_current_queue])
-  
+
   increase_timeout: ->
     c = Math.max(@_current_poll_timeout, @_min_poll_timeout)
     @_current_poll_timeout = Math.min(@_max_poll_timeout, c * 4 / 3)
@@ -110,13 +110,13 @@ class Worker extends EventEmitter
 
   reset_timeout: ->
     @_current_poll_timeout = 1
-  
+
   process_command: (envelope) ->
     @reset_timeout()
-    
+
     command = Worker.registry.get(envelope.command)
     return @error("Unknown command: #{envelope.command}", envelope) unless command?
-    
+
     worker = @_child_workers.shift()
 
     @emit('log', "Processing #{envelope.command}", envelope)
@@ -126,7 +126,7 @@ class Worker extends EventEmitter
       worker: worker
     }
     @_current_commands[envelope.id] = status
-    
+
     on_message = (msg) =>
       if msg.status is 'error'
         @_child_workers.push(status.worker)
@@ -136,9 +136,12 @@ class Worker extends EventEmitter
         @_child_workers.push(status.worker)
         @success(envelope)
         # child.kill()
-    
+
+      # If this is the last in a graceful shutdown
+      @graceful_stop() if @ready_for_graceful()
+
     status.worker.once 'message', on_message
-    
+
     log "Sending #{envelope.command} to worker #{status.worker.pid}"
     status.worker.send {command: envelope.command, opts: envelope.value}
 
@@ -146,7 +149,7 @@ class Worker extends EventEmitter
     delete @_current_commands[envelope.id]
     envelope.remove()
     @emit('success', envelope)
-  
+
   error: (err, envelope) ->
     delete @_current_commands[envelope.id]
     if envelope?
@@ -155,18 +158,19 @@ class Worker extends EventEmitter
 
     err = new Error(err) if typeof err is 'string'
     @emit('failure', err, envelope)
-  
+
   no_envelope: ->
     @emit('log', 'Waiting for more commands')
     @increase_timeout()
-  
+
   ready_for_next: ->
     Object.keys(@_current_commands).length < @_concurrent_commands and @_child_workers.length > 0
-  
+
   next: (timeout) ->
     setTimeout((=> @work()), timeout || @_current_poll_timeout)
-  
+
   work: ->
+    return @graceful_stop() if @ready_for_graceful()
     return unless @_state is 'running'
     return @next(@increase_timeout()) unless @ready_for_next()
 
@@ -180,7 +184,7 @@ class Worker extends EventEmitter
       else
         @process_command(envelope)
       @next()
-  
+
   start: (callback) ->
     return require('./worker_child') if @_is_child
 
@@ -200,10 +204,19 @@ class Worker extends EventEmitter
           callback?()
       when 'initializing'
         @.once('initialized', -> callback?())
-  
+
   stop: (callback) ->
     @_state = 'stopping'
-  
+
+  graceful: (callback) ->
+    @_state = 'graceful'
+
+  graceful_stop: () ->
+    process.exit(0)
+
+  ready_for_graceful: () ->
+    _.keys(@_current_commands).length is 0 and @_state is 'graceful'
+
   info: (callback) ->
     mem = process.memoryUsage()
     o = {
@@ -242,12 +255,12 @@ class Worker extends EventEmitter
       o.stats.children = children
       o.stats.resident_total = procinfo.pretty(o.stats.resident_total)
       callback(null, o)
-  
+
   @workers: (callback) ->
     create_client().keys "#{settings.namespace}:worker:*", (err, keys) ->
       return callback(err) if err?
       callback(null, keys.map (k) -> k.slice("#{settings.namespace}:worker:".length))
-  
+
   @stats: (callback) ->
     client = create_client()
 
@@ -260,5 +273,5 @@ class Worker extends EventEmitter
           _.extend({type: 'worker', full_name: w.name}, flatten_object(w.stats))
 
         callback(null, data)
-  
+
 module.exports = Worker

--- a/lib/worker.coffee
+++ b/lib/worker.coffee
@@ -210,10 +210,11 @@ class Worker extends EventEmitter
 
   graceful: (callback) ->
     @_state = 'graceful'
-    callback?()
+    @_graceful_callback = callback if callback?
 
   graceful_stop: () ->
     _.map(@_child_workers, (w) -> w.kill('SIGHUP'))
+    @_graceful_callback() if @_graceful_callback?
     process.exit(0)
 
   ready_for_graceful: () ->

--- a/lib/worker.coffee
+++ b/lib/worker.coffee
@@ -205,12 +205,11 @@ class Worker extends EventEmitter
       when 'initializing'
         @.once('initialized', -> callback?())
 
-  stop: (callback) ->
+  stop: () ->
     @_state = 'stopping'
 
   graceful: (callback) ->
     @_state = 'graceful'
-    @_graceful_callback = callback if callback?
 
   graceful_stop: () ->
     _.map(@_child_workers, (w) -> w.kill('SIGHUP'))


### PR DESCRIPTION
Workers now have a "graceful" method which, when called, will cause them to shutdown in a graceful fashion, first by refusing to take any new jobs from the queue and then only exiting when the last of the its current jobs has finished execution. 
